### PR TITLE
feature: Handle anchor links

### DIFF
--- a/contentful_converter.gemspec
+++ b/contentful_converter.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = 'Converts HTML text to Rich Text Contentful specific JSON structure'
   s.authors     = ['Alex Avlonitis']
   s.files       = Dir.glob('{bin,lib}/**/*') + %w[README.md]
-  s.homepage    = 'https://github.com/AlexAvlonitis/contentful_converter'
+  s.homepage    = 'https://github.com/citizensadvice/contentful_converter.git'
   s.license     = 'MIT'
 
   s.add_dependency 'nokogiri', '~> 1.6'

--- a/lib/contentful_converter/nodes/hyperlink.rb
+++ b/lib/contentful_converter/nodes/hyperlink.rb
@@ -10,14 +10,14 @@ module ContentfulConverter
 
       def type
         return 'asset-hyperlink' if !uri_scheme? && uri_extension?
-        return 'entry-hyperlink' unless uri_scheme?
+        return 'entry-hyperlink' if !uri_scheme? && !parsed_link.to_s.include?("#")
 
         'hyperlink'
       end
 
       def options
         return hyperlink_entry_option('Asset') if !uri_scheme? && uri_extension?
-        return hyperlink_entry_option('Entry') unless uri_scheme?
+        return hyperlink_entry_option('Entry') if !uri_scheme? && !parsed_link.to_s.include?("#")
 
         hyperlink_option
       end

--- a/lib/contentful_converter/version.rb
+++ b/lib/contentful_converter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentfulConverter
-  VERSION = '0.0.1.26'
+  VERSION = '0.0.1.27'
 end

--- a/spec/features/html_to_rich_text_test.rb
+++ b/spec/features/html_to_rich_text_test.rb
@@ -142,42 +142,82 @@ describe ContentfulConverter::Converter do
         end
 
         context 'when the link does not have a protocol' do
-          let(:html) do
-            '<html><body><a href="12398sadkcw">hyperlink entry</a></body></html>'
-          end
-          let(:expected_hash) do
-            {
-              nodeType: 'document',
-              data: {},
-              content: [
-                {
-                  nodeType: 'paragraph',
-                  data: {},
-                  content: [
-                    {
-                      nodeType: 'entry-hyperlink',
-                      data: {
-                        target: {
-                          sys: {
-                            id: '12398sadkcw',
-                            type: 'Link',
-                            linkType: 'Entry'
+          context 'when the link does not contain a hash' do
+            let(:html) do
+              '<html><body><a href="12398sadkcw">hyperlink entry</a></body></html>'
+            end
+            let(:expected_hash) do
+              {
+                nodeType: 'document',
+                data: {},
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    data: {},
+                    content: [
+                      {
+                        nodeType: 'entry-hyperlink',
+                        data: {
+                          target: {
+                            sys: {
+                              id: '12398sadkcw',
+                              type: 'Link',
+                              linkType: 'Entry'
+                            }
                           }
-                        }
-                      },
-                      content: [
-                        {
-                          data: {},
-                          marks: [],
-                          value: 'hyperlink entry',
-                          nodeType: 'text'
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+                        },
+                        content: [
+                          {
+                            data: {},
+                            marks: [],
+                            value: 'hyperlink entry',
+                            nodeType: 'text'
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            end
+
+            it 'creates a hyperlink entry with the href as a link id' do
+              expect(described_class.convert(html)).to eq expected_hash
+            end
+          end
+
+          context 'when the link contains a hash' do
+            let(:html) do
+              '<html><body><a href="12398sadkcw/#h-something">hyperlink entry</a></body></html>'
+            end
+            let(:expected_hash) do
+              {
+                nodeType: 'document',
+                data: {},
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    data: {},
+                    content: [
+                      {
+                        nodeType: 'hyperlink',
+                        data: {
+                          uri: '12398sadkcw/#h-something'
+                        },
+                        content: [
+                          {
+                            data: {},
+                            marks: [],
+                            value: 'hyperlink entry',
+                            nodeType: 'text'
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            end
           end
 
           it 'creates a hyperlink entry with the href as a link id' do


### PR DESCRIPTION
There were 3 types of links that we can receive in the API extract:
1) Links to other migrated pages - these are known as entry-hyperlinks
2) Links to assets - known as asset-hyperlinks
3) Links to external webpages - known as hyperlinks

We now want to handle a 4th type - anchor links. These arrive at the contentful-converter gem in the following form:
`/immigration/something#h-header-name`

Previously, they fulfilled the 'entry' logic when passing through the hyperlink file and we were trying to upload them as entry-hyperlinks (which failed). Instead, we should treat them as if they were external webpages (hyperlinks) and upload them as such.