### PR TITLE
Test for new bug: hyperlinks in bold tags

### DIFF
--- a/spec/features/html_to_rich_text_spec.rb
+++ b/spec/features/html_to_rich_text_spec.rb
@@ -595,6 +595,24 @@ describe ContentfulConverter::Converter do
         end
       end
 
+      context 'when there is a hyperlink' do
+        let(:html) do
+          '<html><body><a href="blog.html">awesome blog</a></body></html>'
+        end
+        it 'links to the resource' do
+          expect(described_class.convert(html).to_s).to include("blog.html")
+        end
+      end
+
+      context 'when there is a hyperlink in a bold tag' do
+        let(:html) do
+          '<html><body><b>visit my <a href="blog.html">awesome blog</a></b></body></html>'
+        end
+        it 'links to the resource' do
+          expect(described_class.convert(html).to_s).to include("blog.html")
+        end
+      end
+
       context 'when a paragraph element is blank' do
         let(:html) do
           '<html><body><p>    </p></body></html>'


### PR DESCRIPTION
0) `html_to_rich_text_test.rb` isn't run by rspec; renamed to `html_to_rich_text_spec.rb`
1) Links that are part of bold tags are deleted:

`<html><body><b>visit my <a href="blog.html">awesome blog</a></b></body></html>`
becomes
`"{:nodeType => \"document\", :data => {}, :content => [{:nodeType => \"paragraph\", :data => {}, :content => [{:value => \"visit my awesome blog\", :marks => [{:type => \"bold\"}], :nodeType => \"text\", :data => {}}]}]}"`
which doesn't contain the hyperlink.

Might be able to take a closer look tomorrow, or might sidestep the issue by modifying the HTML before we send it.

(Only `when there is a hyperlink in a bold tag` fails, the other one is just there for clarity that the test itself is sensible)